### PR TITLE
[unpacking] Fix function parameter unpacking section

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -126,17 +126,13 @@ assert((x, y, z) == (3, 2, 1));
 
 This should only be added if built-in tuple literals are added.
 
-
-### Unpacking function arguments
+### Unpacking function literal parameters
+A function parameter must have a type, so function parameters cannot be unpacked without
+tuple types, which are beyond the scope of this DIP. However, a function literal template
+with an untyped unpack declaration parameter is supported:
 ```d
-void foo((int x, int y), int z){
-    writeln(x, " ", y, " ", z);
-}
-
-foo((1, 2), 3); // "1 2 3\n"
-
-auto dg = ((x,y), z) => writeln(x," ",y," ",z);
-dg((1, 2), 3); // "1 2 3\n"
+alias dg = ((x,y), z) => writeln(x," ",y," ",z);
+dg(tuple(1, 2), 3); // "1 2 3\n"
 ```
 
 `((x,y), z){ ... }` is lowered to `(__arg0, z){ auto (x,y) = __arg0; ...}`. In general, it preserves and copies storage classes from


### PR DESCRIPTION
Only function *literal* parameters can be unpacked for now - diff includes rationale. From @tgehr's email:

> Proposal 5. Without built-in tuple types, the implementation only
works for lambdas

Also:
A literal template cannot be assigned to an auto var. 
Use `tuple` instead of tuple literal.

