### PR TITLE
[unpacking] Improve `foreach` section

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -113,8 +113,8 @@ foreach((int x, string y); [tuple(1, "2"), tuple(3, "4"), tuple(5, "6")]) {
     writeln(x, " ", y);// "1 2\n3 4\n5 6"
 }
 ```
-Only the element variable can be unpacked. An index variable can also be declared alongside
-an unpacked element variable (when the *ForeachAggregate* supports it).
+An index variable can be declared alongside
+an unpacked element variable (when the *ForeachAggregate* supports it):
 ```d
 import std.typecons : t = tuple;
 
@@ -130,7 +130,14 @@ foreach(i, (j, k); enumerate(arr)) {
     writeln(i," ",j," ",k); // "0 1 2\n1 3 4\n"
 }
 ```
-Normal `foreach` storage classes are supported:
+The index variable can also be unpacked:
+```d
+auto aa = [t(1, 2): "hi", t(3, 4): "bye"];
+foreach ((a, b), s; aa)
+    writeln(a, b, s); // "12hi\n34bye\n"
+```
+Normal `foreach` storage classes are supported, and they can apply to a tuple component
+variable:
 ```d
 auto arr = [t(1, 2), t(3, 4)];
 foreach((ref x, y); arr) {
@@ -144,6 +151,14 @@ foreach(const (x, y); arr) {
     assert(x == 2*y);
 }
 ```
+Unpacking can be used with `static foreach`:
+```d
+static foreach((a, b); [t(1,2), t(3,4)])
+    pragma(msg, a, b); // "12\n34\n"
+```
+Unpacking can also be used with `opApply` and even when a range
+[has an element type which is a value sequence](https://dlang.org/spec/statement.html#front-seq),
+assuming one of the sequence components is itself a sequence. See [examples](#examples).
 
 
 ### Postponed: Unpacking assignments
@@ -292,6 +307,20 @@ void main(){
      }
      import std.algorithm;
      assert(visited[].all!((ref x)=>x[].all));
+
+     // works with ranges of tuples
+     struct TupleRange
+     {
+         size_t i = 1;
+         auto front() => t(i, i + 1);
+         bool empty() => i == 5;
+         void popFront() { i += 2; }
+     }
+     import std.range;
+     foreach (i, (a, b); enumerate(TupleRange()))
+     {
+         writeln(i, a, b); // "012\n134\n"
+     }
 
      // can unpack in lambda parameter list
      [t(1,2),t(2,3)].map!( ((a, b)) => a+b ).each!writeln; // "3\n5\n"


### PR DESCRIPTION
An index variable can be unpacked (sorry, thanks Timon). 
State that static foreach, opApply and tuple ranges are supported.
Add some examples.