### PR TITLE
Fix TupleDeclarator grammar

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -200,7 +200,6 @@ The following grammar additions will be sufficient.
 +     TupleDeclarator , TupleDeclarators
 
 + TupleDeclarator:
-+     ( TupleDeclarators2 )
 +     ( TupleDeclarators2 ) = Initializer
 
 + TupleDeclarators2:
@@ -210,7 +209,7 @@ The following grammar additions will be sufficient.
 
 + TupleDeclarator2:
 +     StorageClasses[opt] Identifier
-+     StorageClasses[opt] BasicType BasicType2[opt] Identifier
++     StorageClasses[opt] BasicType TypeSuffixes[opt] Identifier
 +     StorageClasses[opt] ( TupleDeclarators2 )
 ```
 

--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -227,7 +227,7 @@ The following grammar additions will be sufficient.
 
 + ForeachTupleDeclarator2:
 +     ForeachTypeAttributes[opt] Identifier
-+     ForeachTypeAttributes[opt] BasicType BasicType2[opt] Identifier
++     ForeachTypeAttributes[opt] BasicType TypeSuffixes[opt] Identifier
 +     ForeachTypeAttributes[opt] ( ForeachTupleDeclarators2 )
 ```
 

--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -187,8 +187,7 @@ The following grammar additions will be sufficient.
 (Note that many grammar rules are repeated due to (existing) distinct restrictions on what `StorageClasses` are allowed; this can make the proposed grammar changes look more profound than they are.)
 
 #### Unpacking declarations
-(Note that ForeachTupleDeclarators2 is the same as TupleDeclarators2 except that the former allows all `StorageClasses`, while the latter allows only `ForeachTypeAttributes`.)
-
+See <https://dlang.org/spec/declaration.html#VarDeclarations>.
 ```diff
   VarDeclarations:
       ...
@@ -214,6 +213,9 @@ The following grammar additions will be sufficient.
 ```
 
 #### Unpacking `foreach` elements
+(Note that `ForeachTupleDeclarators2` is the same as `TupleDeclarators2` except that the latter allows all `StorageClasses`, while the former allows only `ForeachTypeAttributes`.)
+
+See <https://dlang.org/spec/statement.html#ForeachType>.
 ```diff
   ForeachType:
       ...


### PR DESCRIPTION
Top-level parens must have an initializer.
Note that nested tuple patterns are covered by TupleDeclarator2. 
BasicType2 [got renamed](https://dlang.org/spec/declaration.html#variable-declarations) to TypeSuffixes.