### PR TITLE
[unpacking] Update `Parameter` grammar

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -233,8 +233,15 @@ The following grammar additions will be sufficient.
 ```
 
 #### Proposal 5 (Unpacking function arguments)
-(Note that ParameterTupleDeclarator is the same as TupleDeclarator except that the former allows all `StorageClasses`, while the latter allows only `InOut`.)
+(Note that `ParameterTupleDeclarator2` is the same as `TupleDeclarator2` except that the latter allows all `StorageClasses`, while the former allows only `ParameterAttributes`.)
+
+See <https://dlang.org/spec/function.html#Parameter>.
 ```diff
+Parameter:
+      ...
+      ParameterDeclaration = AssignExpression ...
++     ParameterAttributes[opt] ParameterTupleDeclarator
+
 + ParameterTupleDeclarator:
 +     ( ParameterTupleDeclarators2 )
 +     ( ParameterTupleDeclarators2 ) = Initializer
@@ -245,16 +252,9 @@ The following grammar additions will be sufficient.
 +     ParameterTupleDeclarator2 , ParameterTupleDeclarators2
 
 + ParameterTupleDeclarator2:
-+     InOut[opt] Identifier
-+     InOut[opt] BasicType BasicType2[opt] Identifier
-+     InOut[opt] ( ParameterTupleDeclarators2 )
-
-  Parameter:
-      ...
-      InOut[opt] Type ...
-+     InOut[opt] ParameterTupleDeclarator
-
-TODO: FUNCTION LITERALS
++     ParameterAttributes[opt] Identifier
++     ParameterAttributes[opt] BasicType TypeSuffixes[opt] Identifier
++     ParameterAttributes[opt] ( ParameterTupleDeclarators2 )
 ```
 
 


### PR DESCRIPTION
Fix former/latter.
Add link.
List `Parameter` first (by convention) rather than last, update existing item. 
InOut is now ParameterAttributes.
BasicType2 is now TypeSuffixes.
Remove TODO about function literals as [they use `Parameters` anyway](https://dlang.org/spec/expression.html#function_literals).