### PR TITLE
[unpacking] Update Limitations section

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -387,18 +387,6 @@ void main() {
 
 
 ### Limitations
-Currently, slices of `std.typecons.Tuple`s auto-expand. Ideally, slicing a tuple would produce another tuple (instead of an AliasSeq).
-As this DIP is based on rewriting to the current implementation of `std.typecons.Tuple`, this situation is unfortunately not addressed:
-
-```d
-void foo((int, double) t){}
-
-foo((1, 2.0, "3")[0..2]); // error
-
-foo(((1, 2.0, "3")[0..2],)); // ok
-```
-
-This illustrates another limitation: it is still not possible to call a function that takes a single tuple with multiple arguments.
 
 ## Acknowledgements
 

--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -387,6 +387,30 @@ void main() {
 
 
 ### Limitations
+* Moving elements (rather than copying) from the value sequence is not supported.
+
+* Unpacking from a container with a statically known length is not supported unless
+  it implicitly converts to a value sequence. Better support for this could be added in
+  the future. Note that a static array `sa` can be unpacked using
+  [`sa.tupleof`](https://dlang.org/spec/arrays.html#array-properties).
+
+* Unpacking in function parameter lists (that are not function literals) is not supported,
+  but should be if built-in tuple types are added.
+
+* Declaring a variable that is a type sequence instance is not supported by the current
+  implementation, but should work:
+  ```d
+  import std.meta, std.typecons;
+  auto (AliasSeq!(int, int) x, y) = tuple(1, 2, 3);
+  ```
+
+* Unpacking zero elements should be supported for generic programming:
+  ```d
+  auto () = tuple();
+  auto (a, ()) = tuple(1, tuple());
+  ```
+  The current implementation does not support this, due to
+  <https://github.com/dlang/dmd/issues/20842>.
 
 ## Acknowledgements
 


### PR DESCRIPTION
These are mostly describing @tgehr's points in yesterday's email, except I added:
* An item for unpacking from a container with a statically known length
* An example for 0-size unpacking: `auto (a, ()) = tuple(1, tuple());`