### PR TITLE
[unpacking] Tweak Examples section

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -308,15 +308,21 @@ This DIP introduces completely new syntax and semantics, and as such, it cannot 
 
 ### Examples
 ```d
-import std.typecons:t=tuple,T=Tuple;
-void main(){
+import std.stdio : writeln;
+import std.typecons : t = tuple, T = Tuple;
+
+unittest{
      // unpack declarations
      auto (a, (b, c)) = t(1, t(2, "3"));
      assert(t(a, b, c) == t(1, 2, "3"));
 
-     import std.stdio, std.string, std.conv;
-     auto (u, v) = readln().strip.split.to!(T!(int,int));
+     import std.string, std.conv;
+     auto (u, v) = "4 5".split.to!(T!(int,int));
+     assert(u == 4);
+     assert(v == 5);
+}
 
+unittest{
      // works with opApply
      static struct Iota2d{
          int start,end;
@@ -336,7 +342,9 @@ void main(){
      }
      import std.algorithm;
      assert(visited[].all!((ref x)=>x[].all));
+}
 
+unittest{
      // works with ranges of tuples
      struct TupleRange
      {
@@ -346,11 +354,13 @@ void main(){
          void popFront() { i += 2; }
      }
      import std.range;
-     foreach (i, (a, b); enumerate(TupleRange()))
-     {
+     foreach (i, (a, b); enumerate(TupleRange())) {
          writeln(i, a, b); // "012\n134\n"
      }
+}
 
+unittest{
+     import std.algorithm;
      // can unpack in lambda parameter list
      [t(1,2),t(2,3)].map!( ((a, b)) => a+b ).each!writeln; // "3\n5\n"
 


### PR DESCRIPTION
Add missing `std.stdio` import.
Break examples up into unittests. This avoids shadowing e.g. variable declaration of `a`, and makes examples clearer that they aren't interdependent.
Tweak whitespace a bit.
Replace `readln().strip` with `"4 5"` and add asserts, so it's easier to understand.