### PR TITLE
[unpacking] Tweak rationale & description

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -32,7 +32,7 @@ This DIP proposes built-in language support for tuple unpacking.
   https://forum.dlang.org/post/vbda5s$fng$1@digitalmars.com
 
 ## Rationale
-The D programming language currently supports tuples with the library primitive `std.typecons.Tuple`; however,
+The D programming language currently supports tuples with the library primitive [`std.typecons.Tuple`](https://dlang.org/phobos/std_typecons.html#.Tuple); however,
 unpacking them has to be done manually, and is somewhat inconvenient:
   ```d
   Tuple!(int, string) foo();
@@ -45,8 +45,9 @@ unpacking them has to be done manually, and is somewhat inconvenient:
   d = ab[1];
   ```
 
+Unpacking syntax must be consistent with tuple literals and/or tuple type syntax (if either of those features are supported in future).
 Full tuple syntax built into the language has been an oft-requested feature as far back as 2010 (see the [Links](#Links) section for related forum threads).
-Tuple unpacking syntax has previously been blocked by the comma operator, but as using the result of a comma expression has been deprecated, we are now able
+Tuple literal syntax using parentheses `(1, 2)` was originally blocked by the comma operator. Given that using the result of a comma expression [was made an error](https://dlang.org/changelog/2.079.0.html#comma-deprecation-error) in March 2018, we are able
 to make progress on this first step toward full tuple support in the D language.
 
 
@@ -55,8 +56,8 @@ This DIP includes a series of proposals that add tuple unpacking syntax to D. No
 A DIP for built-in tuples and the accompanying syntax may be proposed at a later date.
 
 Goals of this DIP:
-- Allow unpacking tuples into new variable declarations conveniently, like in other modern languages with built-in tuple destructuring support.
-- Maintain backwards-compatibility with std.typecons.Tuple while keeping a clean semantics.
+- Allow unpacking a value sequence into new variable declarations conveniently, like in other modern languages with built-in tuple destructuring support.
+- Support unpacking a `std.typecons.Tuple`.
 - Keep the changes to the language minimal while achieving the desired semantics.
 
 


### PR DESCRIPTION
Add links.
Explain unpacking syntax must be consistent with any tuple syntax. 
Comma result is an error.
Mention unpacking *sequences* as the 1st goal, as tuples aren't in the language (yet).
Change 2nd goal to support unpacking of `std.typecons.Tuple`. I think the 'maintaining backward-compatibility' wording was meant for the full tuple DIP.