### PR TITLE
[unpacking] Various edits

### DIFF
--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -16,7 +16,7 @@ This DIP proposes built-in language support for tuple unpacking.
   http://forum.dlang.org/post/i8jo6k$sba$1@digitalmars.com
   
   More posts on the topic can be found around October 07, 2010 (threading problems):
-  http://forum.dlang.org/group/general?page=767
+  https://forum.dlang.org/group/general?page=1067
 
 - DIP 32 (listing many alternative proposals): https://wiki.dlang.org/DIP32
 
@@ -33,17 +33,21 @@ This DIP proposes built-in language support for tuple unpacking.
 
 ## Rationale
 The D programming language currently supports tuples with the library primitive [`std.typecons.Tuple`](https://dlang.org/phobos/std_typecons.html#.Tuple); however,
-unpacking them has to be done manually, and is somewhat inconvenient:
+unpacking their elements has to be done manually, and is somewhat inconvenient:
   ```d
+  import std.typecons : Tuple;
+
   Tuple!(int, string) foo();
 
   auto ab = foo(), a = ab[0], b = ab[1];
 
-  int c;
-  string d;
-  c = ab[0];
-  d = ab[1];
+  // Specifying types (or differing storage classes) requires separate declarations
+  auto cd = foo();
+  int c = cd[0];
+  string d = cd[1];
   ```
+
+New declaration syntax could avoid having to declare a temporary variable `ab` or `cd` and manually index it, shortening the above code significantly. Unpacking nested tuples is particularly inconvenient, requiring multiple temporary variable declarations.
 
 Unpacking syntax must be consistent with tuple literals and/or tuple type syntax (if either of those features are supported in future).
 Full tuple syntax built into the language has been an oft-requested feature as far back as 2010 (see the [Links](#Links) section for related forum threads).
@@ -62,7 +66,7 @@ Goals of this DIP:
 
 
 ### Prior art
-A selection of statically typed languages equivalent features:
+Equivalent features in a selection of statically typed languages:
 
 * C++ Structured Binding
     * `auto [x, y] = a;`
@@ -105,11 +109,18 @@ assert(b == "2");
 ```
 
 When there is a storage class for a pattern, each component of the pattern can
-be just an identifier. Each variable type will be inferred from the corresponding
+be just an identifier. Each variable's type will be inferred from the corresponding
 sequence element:
 
 ```d
 auto (a, b) = tuple(1, "2");
+static assert(is(typeof(a) == int));
+static assert(is(typeof(b) == string));
+
+auto (a, immutable b, c) = tuple(1, "2", 3.0);
+static assert(is(typeof(a) == int));
+static assert(is(typeof(b) == immutable string));
+static assert(is(typeof(c) == double));
 ```
 
 The number of values has to match exactly. This restriction may be relaxed in a future DIP.
@@ -120,7 +131,7 @@ auto (a, (b, c)) = tuple(1, tuple("2", 3.0));
 (int a, (string b, double c)) = tuple(1, tuple("2", 3.0));
 ```
 
-In a pattern where at least one component specifies a type, each component needs to specify a type or at least one storage class:
+When a pattern component declares a variable name, it must have either a type specified, or at least one storage class applying to it:
 ```d
 (int a, b) = tuple(1, "2"); // error
 (int a, auto b) = tuple(1, "2"); // ok
@@ -128,13 +139,11 @@ In a pattern where at least one component specifies a type, each component needs
 (int a, (b, c)) = tuple(1, tuple("2", 3.0)); // error
 (int a, auto (b, c)) = tuple(1, tuple("2", 3.0)); // ok
 (int a, (auto b, auto c)) = tuple(1, tuple("2", 3.0)); // ok
-
-auto (a, immutable b, c) = tuple(1, "2", 3.0); // ok (restriction does not apply to storage classes)
 ```
 
 Note: This rule leaves open the possibility of supporting unpacking tuple components into
 a new variable declaration and [an existing lvalue expression](#postponed-unpacking-assignments)
-within the same unpack declaration.
+within the same unpack declaration (like in C#).
 
 `static` or `enum` can be applied to the whole declaration, but not to individual components.
 
@@ -414,6 +423,9 @@ void main() {
   it implicitly converts to a value sequence. Better support for this could be added in
   the future. Note that a static array `sa` can be unpacked using
   [`sa.tupleof`](https://dlang.org/spec/arrays.html#array-properties).
+
+* Unpacking fields from an aggregate type instance is not supported, though `.tupleof`
+  can again be used to obtain an lvalue sequence.
 
 * Unpacking in function parameter lists (that are not function literals) is not supported,
   but should be if built-in tuple types are added.

--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -123,7 +123,7 @@ static assert(is(typeof(b) == immutable string));
 static assert(is(typeof(c) == double));
 ```
 
-The number of values has to match exactly. This restriction may be relaxed in a future DIP.
+The number of values has to match exactly - see [limitations](#limitations).
 
 Patterns can be nested:
 ```d
@@ -444,6 +444,10 @@ void main() {
   ```
   The current implementation does not support this, due to
   <https://github.com/dlang/dmd/issues/20842>.
+
+* The number of elements has to match exactly. This restriction may be relaxed in a future DIP.
+  For now, slicing the value sequence can remove elements at the front or back before unpacking.
+
 
 ## Acknowledgements
 

--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -151,13 +151,15 @@ within the same unpack declaration (like in C#).
 ### Unpacking `foreach` elements
 Similarly to unpacking variable declarations, `foreach` should also support unpack declarations.
 For consistency with existing `foreach` variable declarations, the `auto` storage class is
-implied unless overridden. The following 2 statements are equivalent:
+implied unless overridden. The following `foreach` statements are equivalent:
 ```d
-foreach((x, y); [tuple(1, "2"), tuple(3, "4"), tuple(5, "6")]) {
+auto arr = [tuple(1, "2"), tuple(3, "4"), tuple(5, "6")];
+
+foreach((x, y); arr) {
     writeln(x, " ", y); // "1 2\n3 4\n5 6"
 }
 
-foreach((int x, string y); [tuple(1, "2"), tuple(3, "4"), tuple(5, "6")]) {
+foreach((int x, string y); arr) {
     writeln(x, " ", y);// "1 2\n3 4\n5 6"
 }
 ```
@@ -166,14 +168,16 @@ an unpacked element variable (when the *ForeachAggregate* supports it):
 ```d
 import std.typecons : t = tuple;
 
+auto arr = [t(1, 2), t(3, 4)];
+
 // declare index for array & unpack tuple elements
-foreach(i, (x, y); [t(1, 2), t(3, 4)]) {
+foreach(i, (x, y); arr) {
     assert(x==2*i+1 && y==2*i+2);
 }
 
 import std.range;
 
-auto arr = [t(1, 2), t(3, 4)];
+// unpack a range of nested tuples
 foreach(i, (j, k); enumerate(arr)) {
     writeln(i," ",j," ",k); // "0 1 2\n1 3 4\n"
 }

--- a/DIPs/DIP1052.md
+++ b/DIPs/DIP1052.md
@@ -326,7 +326,12 @@ Parameter:
 
 
 ### Breaking changes / deprecation process
-This DIP introduces completely new syntax and semantics, and as such, it cannot break existing code.
+This DIP introduces completely new syntax and semantics, and as such, it cannot break existing code. In particular, the following will continue to have the same semantics:
+
+* Any expression statement beginning with a function literal
+* Any [ScopeGuardStatement](https://dlang.org/spec/statement.html#scope-guard-statement)
+
+These can be distinguished in parsing by testing if an `=` token immediately follows the closing parenthesis which matches the first opening parenthesis after the storage class.
 
 
 ### Examples


### PR DESCRIPTION
Update link to 2010 discussions (page changes as new posts are made!). 
Minor wording tweaks.
Use initialization rather than assignment in rationale, explain new syntax would avoid temporary variables and indexing. 
Mention nested unpacking being particularly inconvenient. 
Move `auto` example up, show types of component variables. 
Fix wording to potentially allow specifying a type inside a pattern with a storage class - [`auto (a, int b) = tuple(1, 2);`](https://github.com/dlang/dmd/commit/e4f3b1ab66d5812ae83e3b61c52596ec26fd78c8).
Mention C# allows mixing declarations and assignments while unpacking. 
Mention `.tupleof` to unpack fields.